### PR TITLE
[DRAFT] Refactory of crypto types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16925,18 +16925,18 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.28.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e67c467c38fd24bd5499dc9a18183b31575c12ee549197e3e20d57aa4fe3b7"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]

--- a/cumulus/parachain-template/node/src/chain_spec.rs
+++ b/cumulus/parachain-template/node/src/chain_spec.rs
@@ -13,7 +13,7 @@ pub type ChainSpec = sc_service::GenericChainSpec<(), Extensions>;
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> TPublic {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -48,7 +48,7 @@ pub fn get_collator_keys_from_seed(seed: &str) -> AuraId {
 /// Helper function to generate an account ID from seed
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<TPublic>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
@@ -50,7 +50,7 @@ pub const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 type AccountPublic = <MultiSignature as Verify>::Signer;
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> TPublic {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -59,7 +59,7 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 /// Helper function to generate an account ID from seed.
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<TPublic>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/cumulus/polkadot-parachain/src/chain_spec/mod.rs
+++ b/cumulus/polkadot-parachain/src/chain_spec/mod.rs
@@ -56,7 +56,7 @@ impl Extensions {
 pub type GenericChainSpec = sc_service::GenericChainSpec<(), Extensions>;
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> TPublic {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -67,7 +67,7 @@ type AccountPublic = <Signature as Verify>::Signer;
 /// Helper function to generate an account ID from seed
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<TPublic>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
@@ -75,6 +75,6 @@ where
 /// Generate collator keys from seed.
 ///
 /// This function's return type must always match the session keys of the chain in tuple format.
-pub fn get_collator_keys_from_seed<AuraId: Public>(seed: &str) -> <AuraId::Pair as Pair>::Public {
+pub fn get_collator_keys_from_seed<AuraId: Public>(seed: &str) -> AuraId {
 	get_from_seed::<AuraId>(seed)
 }

--- a/cumulus/polkadot-parachain/src/service.rs
+++ b/cumulus/polkadot-parachain/src/service.rs
@@ -1245,8 +1245,8 @@ where
 		+ sp_api::ApiExt<Block>
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+		+ sp_consensus_aura::AuraApi<Block, <AuraId as AppCrypto>::Public>,
+	<AuraId as AppCrypto>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	let client2 = client.clone();
@@ -1309,10 +1309,10 @@ where
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>
+		+ sp_consensus_aura::AuraApi<Block, <AuraId as AppCrypto>::Public>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+	<AuraId as AppCrypto>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	start_node_impl::<RuntimeApi, _, _, _>(
@@ -1405,11 +1405,11 @@ where
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>
+		+ sp_consensus_aura::AuraApi<Block, <AuraId as AppCrypto>::Public>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
 		+ cumulus_primitives_aura::AuraUnincludedSegmentApi<Block>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+	<AuraId as AppCrypto>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	start_node_impl::<RuntimeApi, _, _, _>(
@@ -1505,10 +1505,10 @@ where
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>
+		+ sp_consensus_aura::AuraApi<Block, <AuraId as AppCrypto>::Public>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+	<AuraId as AppCrypto>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	start_node_impl::<RuntimeApi, _, _, _>(
@@ -1653,11 +1653,11 @@ where
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>
+		+ sp_consensus_aura::AuraApi<Block, <AuraId as AppCrypto>::Public>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
 		+ cumulus_primitives_aura::AuraUnincludedSegmentApi<Block>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+	<AuraId as AppCrypto>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	start_node_impl::<RuntimeApi, _, _, _>(
@@ -1803,10 +1803,10 @@ where
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>
+		+ sp_consensus_aura::AuraApi<Block, <AuraId as AppCrypto>::Public>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
 		+ cumulus_primitives_aura::AuraUnincludedSegmentApi<Block>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+	<AuraId as AppCrypto>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	start_basic_lookahead_node_impl::<RuntimeApi, _, _, _>(

--- a/cumulus/xcm/xcm-emulator/src/lib.rs
+++ b/cumulus/xcm/xcm-emulator/src/lib.rs
@@ -1586,10 +1586,9 @@ pub mod helpers {
 	}
 
 	/// Helper function to generate an account ID from seed.
-	pub fn get_account_id_from_seed<TPublic: sp_core::Public>(seed: &str) -> AccountId
+	pub fn get_account_id_from_seed<TPublic: sp_core::crypto::Public>(seed: &str) -> AccountId
 	where
-		sp_runtime::MultiSigner:
-			From<<<TPublic as sp_runtime::CryptoType>::Pair as sp_core::Pair>::Public>,
+		sp_runtime::MultiSigner: From<TPublic>,
 	{
 		use sp_runtime::traits::IdentifyAccount;
 		let pubkey = TPublic::Pair::from_string(&format!("//{}", seed), None)

--- a/polkadot/node/collation-generation/src/lib.rs
+++ b/polkadot/node/collation-generation/src/lib.rs
@@ -359,7 +359,7 @@ async fn handle_new_activations<Context>(
 							validation_code_hash,
 							n_validators,
 						},
-						&task_config.key,
+						task_config.key.clone(),
 						&mut task_sender,
 						result_sender,
 						&metrics,
@@ -426,8 +426,14 @@ async fn handle_submit_collation<Context>(
 		n_validators,
 	};
 
-	construct_and_distribute_receipt(collation, &config.key, ctx.sender(), result_sender, metrics)
-		.await;
+	construct_and_distribute_receipt(
+		collation,
+		config.key.clone(),
+		ctx.sender(),
+		result_sender,
+		metrics,
+	)
+	.await;
 
 	Ok(())
 }
@@ -445,7 +451,7 @@ struct PreparedCollation {
 /// which is distributed to validators.
 async fn construct_and_distribute_receipt(
 	collation: PreparedCollation,
-	key: &CollatorPair,
+	key: CollatorPair,
 	sender: &mut impl overseer::CollationGenerationSenderTrait,
 	result_sender: Option<oneshot::Sender<CollationSecondedSignal>>,
 	metrics: &Metrics,

--- a/polkadot/node/collation-generation/src/lib.rs
+++ b/polkadot/node/collation-generation/src/lib.rs
@@ -359,7 +359,7 @@ async fn handle_new_activations<Context>(
 							validation_code_hash,
 							n_validators,
 						},
-						task_config.key.clone(),
+						&task_config.key,
 						&mut task_sender,
 						result_sender,
 						&metrics,
@@ -426,14 +426,8 @@ async fn handle_submit_collation<Context>(
 		n_validators,
 	};
 
-	construct_and_distribute_receipt(
-		collation,
-		config.key.clone(),
-		ctx.sender(),
-		result_sender,
-		metrics,
-	)
-	.await;
+	construct_and_distribute_receipt(collation, &config.key, ctx.sender(), result_sender, metrics)
+		.await;
 
 	Ok(())
 }
@@ -451,7 +445,7 @@ struct PreparedCollation {
 /// which is distributed to validators.
 async fn construct_and_distribute_receipt(
 	collation: PreparedCollation,
-	key: CollatorPair,
+	key: &CollatorPair,
 	sender: &mut impl overseer::CollationGenerationSenderTrait,
 	result_sender: Option<oneshot::Sender<CollationSecondedSignal>>,
 	metrics: &Metrics,

--- a/polkadot/node/service/src/chain_spec.rs
+++ b/polkadot/node/service/src/chain_spec.rs
@@ -32,7 +32,7 @@ use sc_chain_spec::ChainSpecExtension;
 #[cfg(any(feature = "westend-native", feature = "rococo-native"))]
 use sc_chain_spec::ChainType;
 use serde::{Deserialize, Serialize};
-use sp_core::{sr25519, Pair, Public};
+use sp_core::crypto::{sr25519, Pair as PairTrait, Public as PublicTrait};
 use sp_runtime::traits::IdentifyAccount;
 #[cfg(feature = "westend-native")]
 use sp_runtime::Perbill;
@@ -710,18 +710,18 @@ pub fn versi_staging_testnet_config() -> Result<RococoChainSpec, String> {
 }
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-	TPublic::Pair::from_string(&format!("//{}", seed), None)
+pub fn get_from_seed<Public: PublicTrait>(seed: &str) -> Public {
+	Public::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
 }
 
 /// Helper function to generate an account ID from seed
-pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
+pub fn get_account_id_from_seed<Public: PublicTrait>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<Public>,
 {
-	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
+	AccountPublic::from(get_from_seed::<Public>(seed)).into_account()
 }
 
 /// Helper function to generate stash, controller and session key from seed

--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -662,7 +662,6 @@ pub struct NewFull {
 
 /// Is this node running as in-process node for a parachain node?
 #[cfg(feature = "full-node")]
-#[derive(Clone)]
 pub enum IsParachainNode {
 	/// This node is running as in-process node for a parachain collator.
 	Collator(CollatorPair),

--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -662,6 +662,7 @@ pub struct NewFull {
 
 /// Is this node running as in-process node for a parachain node?
 #[cfg(feature = "full-node")]
+#[derive(Clone)]
 pub enum IsParachainNode {
 	/// This node is running as in-process node for a parachain collator.
 	Collator(CollatorPair),

--- a/substrate/bin/node-template/node/src/chain_spec.rs
+++ b/substrate/bin/node-template/node/src/chain_spec.rs
@@ -12,7 +12,7 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 pub type ChainSpec = sc_service::GenericChainSpec<RuntimeGenesisConfig>;
 
 /// Generate a crypto pair from seed.
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> TPublic {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -23,7 +23,7 @@ type AccountPublic = <Signature as Verify>::Signer;
 /// Generate an account ID from seed.
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<TPublic>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/substrate/bin/node/cli/src/chain_spec.rs
+++ b/substrate/bin/node/cli/src/chain_spec.rs
@@ -30,7 +30,7 @@ use sc_telemetry::TelemetryEndpoints;
 use serde::{Deserialize, Serialize};
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use sp_consensus_babe::AuthorityId as BabeId;
-use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public};
+use sp_core::crypto::{sr25519, Pair as PairTrait, Public as PublicTrait, UncheckedInto};
 use sp_mixnet::types::AuthorityId as MixnetId;
 use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
@@ -245,18 +245,18 @@ pub fn staging_testnet_config() -> ChainSpec {
 }
 
 /// Helper function to generate a crypto pair from seed.
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-	TPublic::Pair::from_string(&format!("//{}", seed), None)
+pub fn get_from_seed<Public: PublicTrait>(seed: &str) -> Public {
+	Public::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
 }
 
 /// Helper function to generate an account ID from seed.
-pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
+pub fn get_account_id_from_seed<Public: PublicTrait>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<Public>,
 {
-	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
+	AccountPublic::from(get_from_seed::<Public>(seed)).into_account()
 }
 
 /// Helper function to generate stash, controller and session key from seed.

--- a/substrate/bin/node/testing/src/bench.rs
+++ b/substrate/bin/node/testing/src/bench.rs
@@ -628,17 +628,17 @@ pub struct BenchContext {
 
 type AccountPublic = <Signature as Verify>::Signer;
 
-fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-	TPublic::Pair::from_string(&format!("//{}", seed), None)
+fn get_from_seed<P: Public>(seed: &str) -> P {
+	P::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
 }
 
-fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
+fn get_account_id_from_seed<P: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<P>,
 {
-	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
+	AccountPublic::from(get_from_seed::<P>(seed)).into_account()
 }
 
 impl BenchContext {

--- a/substrate/client/authority-discovery/src/worker.rs
+++ b/substrate/client/authority-discovery/src/worker.rs
@@ -46,11 +46,9 @@ use sc_network::{
 	event::DhtEvent, KademliaKey, NetworkDHTProvider, NetworkSigner, NetworkStateInfo, Signature,
 };
 use sp_api::{ApiError, ProvideRuntimeApi};
-use sp_authority_discovery::{
-	AuthorityDiscoveryApi, AuthorityId, AuthorityPair, AuthoritySignature,
-};
+use sp_authority_discovery::{AuthorityDiscoveryApi, AuthorityId, AuthoritySignature};
 use sp_blockchain::HeaderBackend;
-use sp_core::crypto::{key_types, ByteArray, Pair};
+use sp_core::crypto::{key_types, ByteArray, Public};
 use sp_keystore::{Keystore, KeystorePtr};
 use sp_runtime::traits::Block as BlockT;
 
@@ -516,7 +514,7 @@ where
 				let auth_signature = AuthoritySignature::decode(&mut &auth_signature[..])
 					.map_err(Error::EncodingDecodingScale)?;
 
-				if !AuthorityPair::verify(&auth_signature, &record, &authority_id) {
+				if !authority_id.verify(&auth_signature, &record) {
 					return Err(Error::VerifyingDhtPayload)
 				}
 

--- a/substrate/client/cli/src/commands/utils.rs
+++ b/substrate/client/cli/src/commands/utils.rs
@@ -34,9 +34,9 @@ use sp_runtime::{traits::IdentifyAccount, MultiSigner};
 use std::path::PathBuf;
 
 /// Public key type for Runtime
-pub type PublicFor<P> = <P as sp_core::Pair>::Public;
+pub type PublicFor<P> = <P as sp_core::crypto::CryptoType>::Public;
 /// Seed type for Runtime
-pub type SeedFor<P> = <P as sp_core::Pair>::Seed;
+pub type SeedFor<P> = <P as sp_core::crypto::Pair>::Seed;
 
 /// helper method to fetch uri from `Option<String>` either as a file or read from stdin
 pub fn read_uri(uri: Option<&String>) -> error::Result<String> {

--- a/substrate/client/cli/src/commands/verify.rs
+++ b/substrate/client/cli/src/commands/verify.rs
@@ -20,7 +20,7 @@
 
 use crate::{error, params::MessageParams, utils, with_crypto_scheme, CryptoSchemeFlag};
 use clap::Parser;
-use sp_core::crypto::{ByteArray, Ss58Codec};
+use sp_core::crypto::{ByteArray, Pair as TraitPair, Public as TraitPublic, Ss58Codec};
 use std::io::BufRead;
 
 /// The `verify` command
@@ -74,7 +74,7 @@ impl VerifyCmd {
 
 fn verify<Pair>(sig_data: Vec<u8>, message: Vec<u8>, uri: &str) -> error::Result<()>
 where
-	Pair: sp_core::Pair,
+	Pair: TraitPair,
 	Pair::Signature: for<'a> TryFrom<&'a [u8]>,
 {
 	let signature =
@@ -87,7 +87,7 @@ where
 		Pair::Public::from_string(uri)?
 	};
 
-	if Pair::verify(&signature, &message, &pubkey) {
+	if pubkey.verify(&signature, &message) {
 		println!("Signature verifies correctly.");
 	} else {
 		return Err(error::Error::SignatureInvalid)

--- a/substrate/client/consensus/aura/src/lib.rs
+++ b/substrate/client/consensus/aura/src/lib.rs
@@ -47,7 +47,7 @@ use sp_application_crypto::AppPublic;
 use sp_blockchain::HeaderBackend;
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SelectChain};
 use sp_consensus_slots::Slot;
-use sp_core::crypto::Pair;
+use sp_core::crypto::{CryptoType, Pair};
 use sp_inherents::CreateInherentDataProviders;
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, Header, Member, NumberFor};
@@ -70,7 +70,7 @@ pub use sp_consensus_aura::{
 
 const LOG_TARGET: &str = "aura";
 
-type AuthorityId<P> = <P as Pair>::Public;
+type AuthorityId<P> = <P as CryptoType>::Public;
 
 /// Run `AURA` in a compatibility mode.
 ///

--- a/substrate/client/consensus/aura/src/standalone.rs
+++ b/substrate/client/consensus/aura/src/standalone.rs
@@ -30,7 +30,7 @@ use sp_application_crypto::{AppCrypto, AppPublic};
 use sp_blockchain::Result as CResult;
 use sp_consensus::Error as ConsensusError;
 use sp_consensus_slots::Slot;
-use sp_core::crypto::{ByteArray, Pair};
+use sp_core::crypto::{ByteArray, Pair, Public};
 use sp_keystore::KeystorePtr;
 use sp_runtime::{
 	traits::{Block as BlockT, Header, NumberFor, Zero},
@@ -312,7 +312,7 @@ where
 
 		let pre_hash = header.hash();
 
-		if P::verify(&sig, pre_hash.as_ref(), expected_author) {
+		if expected_author.verify(&sig, pre_hash.as_ref()) {
 			Ok((header, slot, seal))
 		} else {
 			Err(SealVerificationError::BadSignature)

--- a/substrate/client/consensus/babe/src/verification.rs
+++ b/substrate/client/consensus/babe/src/verification.rs
@@ -30,10 +30,10 @@ use sp_consensus_babe::{
 		CompatibleDigestItem, PreDigest, PrimaryPreDigest, SecondaryPlainPreDigest,
 		SecondaryVRFPreDigest,
 	},
-	make_vrf_sign_data, AuthorityId, AuthorityPair, AuthoritySignature,
+	make_vrf_sign_data, AuthorityId, AuthoritySignature,
 };
 use sp_consensus_slots::Slot;
-use sp_core::crypto::{Pair, Public, VrfPublic, Wraps};
+use sp_core::crypto::{Public, VrfPublic, Wraps};
 use sp_runtime::{traits::Header, DigestItem};
 
 /// BABE verification parameters
@@ -164,7 +164,7 @@ fn check_primary_header<B: BlockT + Sized>(
 		epoch_index = epoch.clone_for_slot(pre_digest.slot).epoch_index;
 	}
 
-	if !authority_id.verify(&signature, pre_hash) {
+	if !authority_id.verify(&signature, pre_hash.as_ref()) {
 		return Err(babe_err(Error::BadSignature(pre_hash)))
 	}
 
@@ -246,7 +246,7 @@ fn check_secondary_vrf_header<B: BlockT>(
 		epoch_index = epoch.clone_for_slot(pre_digest.slot).epoch_index;
 	}
 
-	if !AuthorityPair::verify(&signature, pre_hash.as_ref(), author) {
+	if !author.verify(&signature, pre_hash.as_ref()) {
 		return Err(Error::BadSignature(pre_hash))
 	}
 

--- a/substrate/client/consensus/babe/src/verification.rs
+++ b/substrate/client/consensus/babe/src/verification.rs
@@ -33,10 +33,7 @@ use sp_consensus_babe::{
 	make_vrf_sign_data, AuthorityId, AuthorityPair, AuthoritySignature,
 };
 use sp_consensus_slots::Slot;
-use sp_core::{
-	crypto::{VrfPublic, Wraps},
-	Pair,
-};
+use sp_core::crypto::{Pair, Public, VrfPublic, Wraps};
 use sp_runtime::{traits::Header, DigestItem};
 
 /// BABE verification parameters
@@ -167,7 +164,7 @@ fn check_primary_header<B: BlockT + Sized>(
 		epoch_index = epoch.clone_for_slot(pre_digest.slot).epoch_index;
 	}
 
-	if !AuthorityPair::verify(&signature, pre_hash, authority_id) {
+	if !authority_id.verify(&signature, pre_hash) {
 		return Err(babe_err(Error::BadSignature(pre_hash)))
 	}
 
@@ -218,7 +215,7 @@ fn check_secondary_plain_header<B: BlockT>(
 		return Err(Error::InvalidAuthor(expected_author.clone(), author.clone()))
 	}
 
-	if !AuthorityPair::verify(&signature, pre_hash.as_ref(), author) {
+	if !author.verify(&signature, pre_hash.as_ref()) {
 		return Err(Error::BadSignature(pre_hash))
 	}
 

--- a/substrate/primitives/application-crypto/src/bandersnatch.rs
+++ b/substrate/primitives/application-crypto/src/bandersnatch.rs
@@ -17,9 +17,8 @@
 
 //! Bandersnatch VRF application crypto types.
 
-use crate::{KeyTypeId, RuntimePublic};
+use crate::{KeyTypeId, RuntimePublic, Vec};
 pub use sp_core::bandersnatch::*;
-use sp_std::vec::Vec;
 
 mod app {
 	crate::app_crypto!(super, sp_core::testing::BANDERSNATCH);

--- a/substrate/primitives/application-crypto/src/bls377.rs
+++ b/substrate/primitives/application-crypto/src/bls377.rs
@@ -15,8 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! BLS12-377 crypto applications.
-use crate::{KeyTypeId, RuntimePublic};
+//! BLS12-377 crypto types.
+
+use crate::{KeyTypeId, RuntimePublic, Vec};
 
 pub use sp_core::bls::bls377::*;
 

--- a/substrate/primitives/application-crypto/src/bls381.rs
+++ b/substrate/primitives/application-crypto/src/bls381.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! BLS12-381 crypto applications.
+//! BLS12-381 crypto types.
 
 pub use sp_core::bls::bls381::*;
 

--- a/substrate/primitives/application-crypto/src/ecdsa.rs
+++ b/substrate/primitives/application-crypto/src/ecdsa.rs
@@ -17,9 +17,7 @@
 
 //! Ecdsa crypto types.
 
-use crate::{KeyTypeId, RuntimePublic};
-
-use sp_std::vec::Vec;
+use crate::{KeyTypeId, RuntimePublic, Vec};
 
 pub use sp_core::ecdsa::*;
 
@@ -34,7 +32,7 @@ pub use app::{Public as AppPublic, Signature as AppSignature};
 impl RuntimePublic for Public {
 	type Signature = Signature;
 
-	fn all(key_type: KeyTypeId) -> crate::Vec<Self> {
+	fn all(key_type: KeyTypeId) -> Vec<Self> {
 		sp_io::crypto::ecdsa_public_keys(key_type)
 	}
 

--- a/substrate/primitives/application-crypto/src/ecdsa_bls377.rs
+++ b/substrate/primitives/application-crypto/src/ecdsa_bls377.rs
@@ -17,7 +17,7 @@
 
 //! ECDSA and BLS12-377 paired crypto applications.
 
-use crate::{KeyTypeId, RuntimePublic};
+use crate::{KeyTypeId, RuntimePublic, Vec};
 
 pub use sp_core::paired_crypto::ecdsa_bls377::*;
 

--- a/substrate/primitives/application-crypto/src/ed25519.rs
+++ b/substrate/primitives/application-crypto/src/ed25519.rs
@@ -17,9 +17,7 @@
 
 //! Ed25519 crypto types.
 
-use crate::{KeyTypeId, RuntimePublic};
-
-use sp_std::vec::Vec;
+use crate::{KeyTypeId, RuntimePublic, Vec};
 
 pub use sp_core::ed25519::*;
 
@@ -34,7 +32,7 @@ pub use app::{Public as AppPublic, Signature as AppSignature};
 impl RuntimePublic for Public {
 	type Signature = Signature;
 
-	fn all(key_type: KeyTypeId) -> crate::Vec<Self> {
+	fn all(key_type: KeyTypeId) -> Vec<Self> {
 		sp_io::crypto::ed25519_public_keys(key_type)
 	}
 

--- a/substrate/primitives/application-crypto/src/lib.rs
+++ b/substrate/primitives/application-crypto/src/lib.rs
@@ -221,6 +221,20 @@ macro_rules! app_crypto_pair_functions_if_std {
 #[macro_export]
 macro_rules! app_crypto_public_full_crypto {
 	($public:ty, $key_type:expr, $crypto_type:expr) => {
+		$crate::wrap! {
+			/// A generic `AppPublic` wrapper type over $public crypto; this has no specific App.
+			#[derive(
+				Clone, Eq, Hash, PartialEq, PartialOrd, Ord,
+				$crate::codec::Encode,
+				$crate::codec::Decode,
+				$crate::RuntimeDebug,
+				$crate::codec::MaxEncodedLen,
+				$crate::scale_info::TypeInfo,
+			)]
+			#[codec(crate = $crate::codec)]
+			pub struct Public($public);
+		}
+
 		impl $crate::CryptoType for Public {
 			type Pair = Pair;
 			type Public = Public;
@@ -245,6 +259,19 @@ macro_rules! app_crypto_public_full_crypto {
 #[macro_export]
 macro_rules! app_crypto_public_not_full_crypto {
 	($public:ty, $key_type:expr, $crypto_type:expr) => {
+		$crate::wrap! {
+			/// A generic `AppPublic` wrapper type over $public crypto; this has no specific App.
+			#[derive(
+				Clone, Eq, Hash, PartialEq, PartialOrd, Ord,
+				$crate::codec::Encode,
+				$crate::codec::Decode,
+				$crate::RuntimeDebug,
+				$crate::codec::MaxEncodedLen,
+				$crate::scale_info::TypeInfo,
+			)]
+			pub struct Public($public);
+		}
+
 		impl $crate::CryptoType for Public {
 			type Public = Public;
 			type Signature = Signature;
@@ -266,20 +293,6 @@ macro_rules! app_crypto_public_not_full_crypto {
 #[macro_export]
 macro_rules! app_crypto_public_common {
 	($public:ty, $sig:ty, $key_type:expr, $crypto_type:expr) => {
-		$crate::wrap! {
-			/// A generic `AppPublic` wrapper type over $public crypto; this has no specific App.
-			#[derive(
-				Clone, Eq, Hash, PartialEq, PartialOrd, Ord,
-				$crate::codec::Encode,
-				$crate::codec::Decode,
-				$crate::RuntimeDebug,
-				$crate::codec::MaxEncodedLen,
-				$crate::scale_info::TypeInfo,
-			)]
-			#[codec(crate = $crate::codec)]
-			pub struct Public($public);
-		}
-
 		$crate::app_crypto_public_common_if_serde!();
 
 		impl $crate::Public for Public {

--- a/substrate/primitives/application-crypto/src/lib.rs
+++ b/substrate/primitives/application-crypto/src/lib.rs
@@ -126,6 +126,7 @@ macro_rules! app_crypto_pair {
 	($pair:ty, $key_type:expr, $crypto_type:expr) => {
 		$crate::wrap! {
 			/// A generic `AppPublic` wrapper type over $pair crypto; this has no specific App.
+			#[derive(Clone)]
 			pub struct Pair($pair);
 		}
 

--- a/substrate/primitives/application-crypto/src/lib.rs
+++ b/substrate/primitives/application-crypto/src/lib.rs
@@ -282,7 +282,7 @@ macro_rules! app_crypto_public_common {
 		$crate::app_crypto_public_common_if_serde!();
 
 		impl $crate::Public for Public {
-			fn verify(&self, sig: &Self::Signature, message: impl AsRef<[u8]>) -> bool {
+			fn verify(&self, sig: &Self::Signature, message: &[u8]) -> bool {
 				self.0.verify(&sig.0, message)
 			}
 		}

--- a/substrate/primitives/application-crypto/src/sr25519.rs
+++ b/substrate/primitives/application-crypto/src/sr25519.rs
@@ -17,9 +17,7 @@
 
 //! Sr25519 crypto types.
 
-use crate::{KeyTypeId, RuntimePublic};
-
-use sp_std::vec::Vec;
+use crate::{KeyTypeId, RuntimePublic, Vec};
 
 pub use sp_core::sr25519::*;
 
@@ -34,7 +32,7 @@ pub use app::{Public as AppPublic, Signature as AppSignature};
 impl RuntimePublic for Public {
 	type Signature = Signature;
 
-	fn all(key_type: KeyTypeId) -> crate::Vec<Self> {
+	fn all(key_type: KeyTypeId) -> Vec<Self> {
 		sp_io::crypto::sr25519_public_keys(key_type)
 	}
 

--- a/substrate/primitives/core/Cargo.toml
+++ b/substrate/primitives/core/Cargo.toml
@@ -47,13 +47,13 @@ itertools = { version = "0.10.3", optional = true }
 
 # full crypto
 array-bytes = { version = "6.1", optional = true }
-ed25519-zebra = { version = "3.1.0", default-features = false, optional = true }
+ed25519-zebra = { version = "3.1.0", default-features = false }
 blake2 = { version = "0.10.4", default-features = false, optional = true }
-libsecp256k1 = { version = "0.7", default-features = false, features = ["static-context"], optional = true }
+libsecp256k1 = { version = "0.7", default-features = false, features = ["static-context"] }
 schnorrkel = { version = "0.11.4", features = ["preaudit_deprecated"], default-features = false }
 merlin = { version = "3.0", default-features = false }
 secp256k1 = { version = "0.28.0", default-features = false, features = ["alloc", "recovery"], optional = true }
-sp-crypto-hashing = { path = "../crypto/hashing", default-features = false, optional = true }
+sp-crypto-hashing = { path = "../crypto/hashing", default-features = false }
 sp-runtime-interface = { path = "../runtime-interface", default-features = false }
 
 # bls crypto
@@ -135,7 +135,6 @@ serde = [
 	"primitive-types/serde_no_std",
 	"scale-info/serde",
 	"secrecy/alloc",
-	"sp-crypto-hashing",
 	"sp-storage/serde",
 ]
 
@@ -145,10 +144,7 @@ serde = [
 full_crypto = [
 	"array-bytes",
 	"blake2",
-	"ed25519-zebra",
-	"libsecp256k1",
 	"secp256k1",
-	"sp-crypto-hashing",
 	"sp-runtime-interface/disable_target_static_assertions",
 ]
 

--- a/substrate/primitives/core/Cargo.toml
+++ b/substrate/primitives/core/Cargo.toml
@@ -52,7 +52,7 @@ blake2 = { version = "0.10.4", default-features = false, optional = true }
 libsecp256k1 = { version = "0.7", default-features = false, features = ["static-context"] }
 schnorrkel = { version = "0.11.4", features = ["preaudit_deprecated"], default-features = false }
 merlin = { version = "3.0", default-features = false }
-secp256k1 = { version = "0.28.0", default-features = false, features = ["alloc", "recovery"], optional = true }
+secp256k1 = { version = "0.28.0", default-features = false, features = ["alloc", "recovery"] }
 sp-crypto-hashing = { path = "../crypto/hashing", default-features = false }
 sp-runtime-interface = { path = "../runtime-interface", default-features = false }
 
@@ -94,6 +94,7 @@ std = [
 	"hash256-std-hasher/std",
 	"impl-serde/std",
 	"itertools",
+	"libsecp256k1/static-context",
 	"libsecp256k1/std",
 	"log/std",
 	"merlin/std",
@@ -144,7 +145,6 @@ serde = [
 full_crypto = [
 	"array-bytes",
 	"blake2",
-	"secp256k1",
 	"sp-runtime-interface/disable_target_static_assertions",
 ]
 

--- a/substrate/primitives/core/src/bandersnatch.rs
+++ b/substrate/primitives/core/src/bandersnatch.rs
@@ -81,8 +81,8 @@ pub struct Public(pub [u8; PUBLIC_SERIALIZED_SIZE]);
 impl_byte_array!(Public, PUBLIC_SERIALIZED_SIZE);
 
 impl TraitPublic for Public {
-	fn verify(&self, signature: &Signature, data: impl AsRef<[u8]>) -> bool {
-		let data = vrf::VrfSignData::new_unchecked(SIGNING_CTX, &[data.as_ref()], None);
+	fn verify(&self, signature: &Signature, data: &[u8]) -> bool {
+		let data = vrf::VrfSignData::new_unchecked(SIGNING_CTX, &[data], None);
 		let signature =
 			vrf::VrfSignature { signature: *signature, pre_outputs: vrf::VrfIosVec::default() };
 		self.vrf_verify(&data, &signature)

--- a/substrate/primitives/core/src/bandersnatch.rs
+++ b/substrate/primitives/core/src/bandersnatch.rs
@@ -37,6 +37,7 @@ use bandersnatch_vrfs::CanonicalSerialize;
 #[cfg(feature = "full_crypto")]
 use bandersnatch_vrfs::SecretKey;
 use codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
+use core::hash::Hash;
 use scale_info::TypeInfo;
 
 use sp_runtime_interface::pass_by::PassByInner;
@@ -46,7 +47,6 @@ use sp_std::{vec, vec::Vec};
 pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"band");
 
 /// Context used to produce a plain signature without any VRF input/output.
-#[cfg(feature = "full_crypto")]
 pub const SIGNING_CTX: &[u8] = b"BandersnatchSigningContext";
 
 #[cfg(feature = "full_crypto")]
@@ -56,10 +56,12 @@ const PUBLIC_SERIALIZED_SIZE: usize = 33;
 const SIGNATURE_SERIALIZED_SIZE: usize = 65;
 const PREOUT_SERIALIZED_SIZE: usize = 33;
 
+#[cfg(feature = "full_crypto")]
 impl_crypto_type!(Pair, Public, Signature);
+#[cfg(not(feature = "full_crypto"))]
+impl_crypto_type!(Public, Signature);
 
 /// Bandersnatch public key.
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
 #[derive(
 	Clone,
 	Copy,
@@ -72,6 +74,7 @@ impl_crypto_type!(Pair, Public, Signature);
 	PassByInner,
 	MaxEncodedLen,
 	TypeInfo,
+	Hash,
 )]
 pub struct Public(pub [u8; PUBLIC_SERIALIZED_SIZE]);
 
@@ -120,8 +123,9 @@ impl<'de> Deserialize<'de> for Public {
 ///
 /// The signature is created via the [`VrfSecret::vrf_sign`] using [`SIGNING_CTX`] as transcript
 /// `label`.
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
-#[derive(Clone, Copy, PartialEq, Eq, Encode, Decode, PassByInner, MaxEncodedLen, TypeInfo)]
+#[derive(
+	Clone, Copy, Hash, PartialEq, Eq, Encode, Decode, PassByInner, MaxEncodedLen, TypeInfo,
+)]
 pub struct Signature([u8; SIGNATURE_SERIALIZED_SIZE]);
 
 impl SignatureTrait for Signature {}

--- a/substrate/primitives/core/src/bls.rs
+++ b/substrate/primitives/core/src/bls.rs
@@ -37,9 +37,11 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(all(not(feature = "std"), feature = "serde"))]
 use sp_std::alloc::{format, string::String};
 
-use w3f_bls::{DoublePublicKey, DoubleSignature, EngineBLS, SerializableToBytes, TinyBLS381};
+use w3f_bls::{
+	DoublePublicKey, DoubleSignature, EngineBLS, Message, SerializableToBytes, TinyBLS381,
+};
 #[cfg(feature = "full_crypto")]
-use w3f_bls::{DoublePublicKeyScheme, Keypair, Message, SecretKey};
+use w3f_bls::{DoublePublicKeyScheme, Keypair, SecretKey};
 
 use sp_runtime_interface::pass_by::{self, PassBy, PassByInner};
 use sp_std::{convert::TryFrom, marker::PhantomData, ops::Deref};
@@ -172,9 +174,8 @@ impl<T> Ord for Public<T> {
 	}
 }
 
-#[cfg(feature = "full_crypto")]
-impl<T> sp_std::hash::Hash for Public<T> {
-	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+impl<T> core::hash::Hash for Public<T> {
+	fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
 		self.inner.hash(state)
 	}
 }

--- a/substrate/primitives/core/src/bls.rs
+++ b/substrate/primitives/core/src/bls.rs
@@ -347,9 +347,8 @@ impl<T> PartialEq for Signature<T> {
 
 impl<T> Eq for Signature<T> {}
 
-#[cfg(feature = "full_crypto")]
-impl<T> sp_std::hash::Hash for Signature<T> {
-	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+impl<T> core::hash::Hash for Signature<T> {
+	fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
 		self.inner.hash(state)
 	}
 }

--- a/substrate/primitives/core/src/crypto.rs
+++ b/substrate/primitives/core/src/crypto.rs
@@ -605,13 +605,6 @@ impl sp_std::str::FromStr for AccountId32 {
 	}
 }
 
-/// Creates an [`AccountId32`] from the input, which should contain at least 32 bytes.
-impl FromEntropy for AccountId32 {
-	fn from_entropy(input: &mut impl codec::Input) -> Result<Self, codec::Error> {
-		Ok(AccountId32::new(FromEntropy::from_entropy(input)?))
-	}
-}
-
 #[cfg(feature = "std")]
 pub use self::dummy::*;
 
@@ -1148,6 +1141,15 @@ macro_rules! impl_byte_array {
 				$struct_name(raw)
 			}
 		}
+
+		impl $crate::crypto::FromEntropy for $struct_name {
+			fn from_entropy(input: &mut impl codec::Input) -> Result<Self, codec::Error> {
+				let buf = $crate::crypto::FromEntropy::from_entropy(input)?;
+				Ok(<$struct_name as $crate::crypto::UncheckedFrom<[u8; $size]>>::unchecked_from(
+					buf,
+				))
+			}
+		}
 	};
 }
 pub(crate) use impl_byte_array;
@@ -1314,8 +1316,9 @@ macro_rules! impl_from_entropy_base {
 			[$type; 9], [$type; 10], [$type; 11], [$type; 12], [$type; 13], [$type; 14], [$type; 15], [$type; 16],
 			[$type; 17], [$type; 18], [$type; 19], [$type; 20], [$type; 21], [$type; 22], [$type; 23], [$type; 24],
 			[$type; 25], [$type; 26], [$type; 27], [$type; 28], [$type; 29], [$type; 30], [$type; 31], [$type; 32],
-			[$type; 36], [$type; 40], [$type; 44], [$type; 48], [$type; 56], [$type; 64], [$type; 72], [$type; 80],
-			[$type; 96], [$type; 112], [$type; 128], [$type; 160], [$type; 177], [$type; 192], [$type; 224], [$type; 256]
+			[$type; 33], [$type; 36], [$type; 40], [$type; 44], [$type; 48], [$type; 56], [$type; 64], [$type; 65],
+			[$type; 72], [$type; 80], [$type; 96], [$type; 112], [$type; 128], [$type; 160], [$type; 177], [$type; 192],
+			[$type; 224], [$type; 256]
 		);
 	}
 }

--- a/substrate/primitives/core/src/crypto.rs
+++ b/substrate/primitives/core/src/crypto.rs
@@ -17,7 +17,7 @@
 
 //! Cryptographic utilities.
 
-// use crate::{ed25519, sr25519};
+use crate::{ed25519, sr25519};
 #[cfg(feature = "std")]
 use bip39::{Language, Mnemonic};
 use codec::{Decode, Encode, MaxEncodedLen};
@@ -533,17 +533,17 @@ impl From<[u8; 32]> for AccountId32 {
 	}
 }
 
-// impl From<sr25519::Public> for AccountId32 {
-// 	fn from(k: sr25519::Public) -> Self {
-// 		k.0.into()
-// 	}
-// }
+impl From<sr25519::Public> for AccountId32 {
+	fn from(k: sr25519::Public) -> Self {
+		k.0.into()
+	}
+}
 
-// impl From<ed25519::Public> for AccountId32 {
-// 	fn from(k: ed25519::Public) -> Self {
-// 		k.0.into()
-// 	}
-// }
+impl From<ed25519::Public> for AccountId32 {
+	fn from(k: ed25519::Public) -> Self {
+		k.0.into()
+	}
+}
 
 #[cfg(feature = "std")]
 impl std::fmt::Display for AccountId32 {

--- a/substrate/primitives/core/src/crypto.rs
+++ b/substrate/primitives/core/src/crypto.rs
@@ -17,7 +17,6 @@
 
 //! Cryptographic utilities.
 
-use crate::{ed25519, sr25519};
 #[cfg(feature = "std")]
 use bip39::{Language, Mnemonic};
 use codec::{Decode, Encode, MaxEncodedLen};
@@ -37,6 +36,8 @@ use sp_std::{
 	vec,
 };
 use sp_std::{hash::Hash, str, vec::Vec};
+
+pub use crate::{ecdsa, ed25519, sr25519};
 pub use ss58_registry::{from_known_address_format, Ss58AddressFormat, Ss58AddressFormatRegistry};
 /// Trait to zeroize a memory buffer.
 pub use zeroize::Zeroize;
@@ -500,7 +501,7 @@ pub trait Public:
 	/// Verify a signature on a message.
 	///
 	/// Returns true if the signature is good.
-	fn verify(&self, sig: &Self::Signature, message: impl AsRef<[u8]>) -> bool;
+	fn verify(&self, sig: &Self::Signature, message: &[u8]) -> bool;
 }
 
 /// An opaque 32-byte cryptographic identifier.
@@ -668,7 +669,7 @@ mod dummy {
 	}
 
 	impl Public for Dummy {
-		fn verify(&self, _: &Dummy, _: impl AsRef<[u8]>) -> bool {
+		fn verify(&self, _: &Dummy, _: &[u8]) -> bool {
 			true
 		}
 	}
@@ -890,7 +891,7 @@ pub trait Pair: CryptoType<Pair = Self> + Sized {
 	/// TODO: Deprecated use `Public::verify()`
 	#[deprecated(note = "Use Public::verify() instead")]
 	fn verify(sig: &Self::Signature, message: impl AsRef<[u8]>, public: &Self::Public) -> bool {
-		public.verify(sig, message)
+		public.verify(sig, message.as_ref())
 	}
 
 	/// Get the public key.
@@ -1016,7 +1017,7 @@ pub trait Signature: CryptoType<Signature = Self> + ByteArray {
 	/// Verify a signature on a message.
 	///
 	/// Returns true if the signature is good.
-	fn verify(&self, public: &Self::Public, message: impl AsRef<[u8]>) -> bool {
+	fn verify(&self, public: &Self::Public, message: &[u8]) -> bool {
 		public.verify(self, message)
 	}
 }
@@ -1422,7 +1423,7 @@ mod tests {
 	impl_byte_array!(TestPublic, 0);
 
 	impl Public for TestPublic {
-		fn verify(&self, _: &TestSignature, _: impl AsRef<[u8]>) -> bool {
+		fn verify(&self, _: &TestSignature, _: &[u8]) -> bool {
 			true
 		}
 	}

--- a/substrate/primitives/core/src/ecdsa.rs
+++ b/substrate/primitives/core/src/ecdsa.rs
@@ -208,8 +208,7 @@ impl<'de> Deserialize<'de> for Public {
 }
 
 /// A signature (a 512-bit value, plus 8 bits for recovery ID).
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
-#[derive(Clone, Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq)]
+#[derive(Clone, Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq, Hash)]
 pub struct Signature(pub [u8; SIGNATURE_SERIALIZED_SIZE]);
 
 impl TraitSignature for Signature {}

--- a/substrate/primitives/core/src/ecdsa.rs
+++ b/substrate/primitives/core/src/ecdsa.rs
@@ -79,14 +79,6 @@ type Seed = [u8; 32];
 )]
 pub struct Public(pub [u8; PUBLIC_KEY_SERIALIZED_SIZE]);
 
-impl crate::crypto::FromEntropy for Public {
-	fn from_entropy(input: &mut impl codec::Input) -> Result<Self, codec::Error> {
-		let mut result = Self([0u8; PUBLIC_KEY_SERIALIZED_SIZE]);
-		input.read(&mut result.0[..])?;
-		Ok(result)
-	}
-}
-
 impl Public {
 	/// A new instance from the given 33-byte `data`.
 	///
@@ -264,12 +256,7 @@ impl Signature {
 	/// NOTE: No checking goes on to ensure this is a real signature. Only use it if
 	/// you are certain that the array actually is a signature. GIGO!
 	pub fn from_slice(data: &[u8]) -> Option<Self> {
-		if data.len() != SIGNATURE_SERIALIZED_SIZE {
-			return None
-		}
-		let mut r = [0u8; SIGNATURE_SERIALIZED_SIZE];
-		r.copy_from_slice(data);
-		Some(Signature(r))
+		Signature::try_from(data).ok()
 	}
 
 	/// Recover the public key from this signature and a message.

--- a/substrate/primitives/core/src/ed25519.rs
+++ b/substrate/primitives/core/src/ed25519.rs
@@ -152,8 +152,9 @@ impl<'de> Deserialize<'de> for Public {
 }
 
 /// A signature (a 512-bit value).
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
-#[derive(Copy, Clone, Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq)]
+#[derive(
+	Copy, Clone, Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq, Hash,
+)]
 pub struct Signature(pub [u8; 64]);
 
 impl_byte_array!(Signature, 64);

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -81,8 +81,8 @@ pub mod sr25519;
 
 #[cfg(feature = "bls-experimental")]
 pub use bls::{bls377, bls381};
-#[cfg(feature = "bls-experimental")]
-pub use paired_crypto::ecdsa_bls377;
+// #[cfg(feature = "bls-experimental")]
+// pub use paired_crypto::ecdsa_bls377;
 
 pub use self::{
 	hash::{convert_hash, H160, H256, H512},

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -81,8 +81,8 @@ pub mod sr25519;
 
 #[cfg(feature = "bls-experimental")]
 pub use bls::{bls377, bls381};
-// #[cfg(feature = "bls-experimental")]
-// pub use paired_crypto::ecdsa_bls377;
+#[cfg(feature = "bls-experimental")]
+pub use paired_crypto::ecdsa_bls377;
 
 pub use self::{
 	hash::{convert_hash, H160, H256, H512},

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -57,26 +57,27 @@ pub mod const_hex2array;
 pub mod crypto;
 pub mod hexdisplay;
 pub use paste;
-
-#[cfg(any(feature = "full_crypto", feature = "std"))]
-mod address_uri;
-#[cfg(feature = "bandersnatch-experimental")]
-pub mod bandersnatch;
-#[cfg(feature = "bls-experimental")]
-pub mod bls;
 pub mod defer;
-pub mod ecdsa;
-pub mod ed25519;
 pub mod hash;
-#[cfg(feature = "std")]
-mod hasher;
 pub mod offchain;
-pub mod paired_crypto;
-pub mod sr25519;
 pub mod testing;
 #[cfg(feature = "std")]
 pub mod traits;
 pub mod uint;
+
+#[cfg(any(feature = "full_crypto", feature = "std"))]
+mod address_uri;
+#[cfg(feature = "std")]
+mod hasher;
+
+#[cfg(feature = "bandersnatch-experimental")]
+pub mod bandersnatch;
+#[cfg(feature = "bls-experimental")]
+pub mod bls;
+pub mod ecdsa;
+pub mod ed25519;
+pub mod paired_crypto;
+pub mod sr25519;
 
 #[cfg(feature = "bls-experimental")]
 pub use bls::{bls377, bls381};

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -308,7 +308,7 @@ impl<LeftPublic: PublicT, RightPublic: PublicT, const LEFT_PLUS_RIGHT_LEN: usize
 where
 	Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>: CryptoType<Public = Self>,
 {
-	fn verify(&self, sig: &Self::Signature, message: impl AsRef<[u8]>) -> bool {
+	fn verify(&self, sig: &Self::Signature, message: &[u8]) -> bool {
 		let left_sig_len = <LeftPublic::Signature as ByteArray>::LEN;
 		let Ok(left_pub): Result<LeftPublic, _> = self.inner[..LeftPublic::LEN].try_into() else {
 			return false
@@ -594,7 +594,7 @@ mod test {
 		);
 		let signature = Signature::unchecked_from(signature);
 		assert!(pair.sign(&message[..]) == signature);
-		assert!(Pair::verify(&signature, &message[..], &public));
+		assert!(public.verify(&signature, &message[..]));
 	}
 
 	#[test]
@@ -618,7 +618,7 @@ mod test {
 	);
 		let signature = Signature::unchecked_from(signature);
 		assert!(pair.sign(&message[..]) == signature);
-		assert!(Pair::verify(&signature, &message[..], &public));
+		assert!(public.verify(&signature, &message[..]));
 	}
 
 	#[test]
@@ -627,8 +627,8 @@ mod test {
 		let public = pair.public();
 		let message = b"Something important";
 		let signature = pair.sign(&message[..]);
-		assert!(Pair::verify(&signature, &message[..], &public));
-		assert!(!Pair::verify(&signature, b"Something else", &public));
+		assert!(public.verify(&signature, &message[..]));
+		assert!(!public.verify(&signature, b"Something else"));
 	}
 
 	#[test]
@@ -647,8 +647,8 @@ mod test {
 	    );
 		let signature = pair.sign(&message[..]);
 		println!("Correct signature: {:?}", signature);
-		assert!(Pair::verify(&signature, &message[..], &public));
-		assert!(!Pair::verify(&signature, "Other message", &public));
+		assert!(public.verify(&signature, &message[..]));
+		assert!(!public.verify(&signature, b"Other message"));
 	}
 
 	#[test]
@@ -708,7 +708,7 @@ mod test {
 		// Signature is 177 bytes, hexify * 2 + 2 quote charsy
 		assert_eq!(serialized_signature.len(), 356);
 		let signature = serde_json::from_str(&serialized_signature).unwrap();
-		assert!(Pair::verify(&signature, message, &pair.public()));
+		assert!(pair.public().verify(&signature, message));
 	}
 
 	#[test]

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -249,7 +249,7 @@ impl<L, R, const LEFT_PLUS_RIGHT_LEN: usize> UncheckedFrom<[u8; LEFT_PLUS_RIGHT_
 impl<L: PublicT, R: PublicT, const LEFT_PLUS_RIGHT_LEN: usize> std::fmt::Display
 	for Public<L, R, LEFT_PLUS_RIGHT_LEN>
 where
-	Public<L, R, LEFT_PLUS_RIGHT_LEN>: CryptoType,
+	Public<L, R, LEFT_PLUS_RIGHT_LEN>: CryptoType<Public = Self>,
 {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(f, "{}", self.to_ss58check())
@@ -259,7 +259,7 @@ where
 impl<L: PublicT, R: PublicT, const LEFT_PLUS_RIGHT_LEN: usize> sp_std::fmt::Debug
 	for Public<L, R, LEFT_PLUS_RIGHT_LEN>
 where
-	Self: CryptoType,
+	Self: CryptoType<Public = Self>,
 	[u8; LEFT_PLUS_RIGHT_LEN]: crate::hexdisplay::AsBytesRef,
 {
 	#[cfg(feature = "std")]
@@ -278,7 +278,7 @@ where
 impl<L: PublicT, R: PublicT, const LEFT_PLUS_RIGHT_LEN: usize> Serialize
 	for Public<L, R, LEFT_PLUS_RIGHT_LEN>
 where
-	Self: CryptoType,
+	Self: CryptoType<Public = Self>,
 {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -292,7 +292,7 @@ where
 impl<'de, L: PublicT, R: PublicT, const LEFT_PLUS_RIGHT_LEN: usize> Deserialize<'de>
 	for Public<L, R, LEFT_PLUS_RIGHT_LEN>
 where
-	Self: CryptoType,
+	Self: CryptoType<Public = Self>,
 {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
@@ -306,7 +306,7 @@ where
 impl<LeftPublic: PublicT, RightPublic: PublicT, const LEFT_PLUS_RIGHT_LEN: usize> PublicT
 	for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
 where
-	Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>: CryptoType,
+	Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>: CryptoType<Public = Self>,
 {
 	fn verify(&self, sig: &Self::Signature, message: impl AsRef<[u8]>) -> bool {
 		let left_sig_len = <LeftPublic::Signature as ByteArray>::LEN;
@@ -333,7 +333,7 @@ impl<L, R, const LEFT_PLUS_RIGHT_LEN: usize> Derive for Public<L, R, LEFT_PLUS_R
 pub struct Signature<const LEFT_PLUS_RIGHT_LEN: usize>([u8; LEFT_PLUS_RIGHT_LEN]);
 
 impl<const LEFT_PLUS_RIGHT_LEN: usize> SignatureT for Signature<LEFT_PLUS_RIGHT_LEN> where
-	Signature<LEFT_PLUS_RIGHT_LEN>: CryptoType
+	Signature<LEFT_PLUS_RIGHT_LEN>: CryptoType<Signature = Self>
 {
 }
 
@@ -456,7 +456,7 @@ impl<
 		const SIGNATURE_LEN: usize,
 	> PairT for Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>
 where
-	Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>: CryptoType,
+	Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>: CryptoType<Pair = Self>,
 	LeftPair::Seed: From<Seed> + Into<Seed>,
 	RightPair::Seed: From<Seed> + Into<Seed>,
 	Self::Public: UncheckedFrom<[u8; PUBLIC_KEY_LEN]>,

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -66,7 +66,10 @@ pub mod ecdsa_bls377 {
 	/// (ECDSA,BLS12-377) signature pair.
 	pub type Signature = super::Signature<SIGNATURE_LEN>;
 
+	#[cfg(feature = "full_crypto")]
 	impl_crypto_type!(Pair, Public, Signature);
+	#[cfg(not(feature = "full_crypto"))]
+	impl_crypto_type!(Public, Signature);
 
 	#[cfg(feature = "full_crypto")]
 	impl Pair {
@@ -150,11 +153,10 @@ pub struct Public<L, R, const LEFT_PLUS_RIGHT_LEN: usize> {
 	_phantom: PhantomData<(L, R)>,
 }
 
-#[cfg(feature = "full_crypto")]
-impl<L, R, const LEFT_PLUS_RIGHT_LEN: usize> sp_std::hash::Hash
+impl<L, R, const LEFT_PLUS_RIGHT_LEN: usize> core::hash::Hash
 	for Public<L, R, LEFT_PLUS_RIGHT_LEN>
 {
-	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+	fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
 		self.inner.hash(state);
 	}
 }
@@ -339,9 +341,8 @@ impl<const LEFT_PLUS_RIGHT_LEN: usize> ByteArray for Signature<LEFT_PLUS_RIGHT_L
 	const LEN: usize = LEFT_PLUS_RIGHT_LEN;
 }
 
-#[cfg(feature = "full_crypto")]
-impl<const LEFT_PLUS_RIGHT_LEN: usize> sp_std::hash::Hash for Signature<LEFT_PLUS_RIGHT_LEN> {
-	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+impl<const LEFT_PLUS_RIGHT_LEN: usize> core::hash::Hash for Signature<LEFT_PLUS_RIGHT_LEN> {
+	fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
 		self.0.hash(state);
 	}
 }

--- a/substrate/primitives/core/src/sr25519.rs
+++ b/substrate/primitives/core/src/sr25519.rs
@@ -236,12 +236,12 @@ impl Public {
 	///
 	/// NOTE: No checking goes on to ensure this is a real public key. Only use it if
 	/// you are certain that the array actually is a pubkey. GIGO!
-	pub fn from_raw(data: [u8; 32]) -> Self {
+	pub fn from_raw(data: [u8; PUBLIC_KEY_SERIALIZED_SIZE]) -> Self {
 		Public(data)
 	}
 
 	/// Return a slice filled with raw data.
-	pub fn as_array_ref(&self) -> &[u8; 32] {
+	pub fn as_array_ref(&self) -> &[u8; PUBLIC_KEY_SERIALIZED_SIZE] {
 		self.as_ref()
 	}
 }
@@ -301,9 +301,7 @@ impl TraitPair for Pair {
 
 	/// Get the public key.
 	fn public(&self) -> Public {
-		let mut pk = [0u8; 32];
-		pk.copy_from_slice(&self.0.public.to_bytes());
-		Public(pk)
+		Public(self.0.public.to_bytes())
 	}
 
 	/// Make a new key pair from raw secret seed material.

--- a/substrate/primitives/core/src/sr25519.rs
+++ b/substrate/primitives/core/src/sr25519.rs
@@ -292,10 +292,10 @@ impl Public {
 impl_byte_array!(Public, 32);
 
 impl TraitPublic for Public {
-	fn verify(&self, sig: &Signature, message: impl AsRef<[u8]>) -> bool {
+	fn verify(&self, sig: &Signature, message: &[u8]) -> bool {
 		let Ok(public) = PublicKey::from_bytes(self.as_ref()) else { return false };
 		let Ok(signature) = schnorrkel::Signature::from_bytes(sig.as_ref()) else { return false };
-		public.verify_simple(SIGNING_CTX, message.as_ref(), &signature).is_ok()
+		public.verify_simple(SIGNING_CTX, message, &signature).is_ok()
 	}
 }
 
@@ -879,7 +879,7 @@ mod tests {
 		let public = pair.public();
 		let message = b"Something important";
 		let signature = pair.sign(message);
-		assert!(!public.verify(&signature, &b"Something unimportant"));
+		assert!(!public.verify(&signature, b"Something unimportant"));
 	}
 
 	#[test]
@@ -894,7 +894,7 @@ mod tests {
 		);
 		let message = array_bytes::hex2bytes_unchecked("2f8c6129d816cf51c374bc7f08c3e63ed156cf78aefb4a6550d97b87997977ee00000000000000000200d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a4500000000000000");
 		let signature = pair.sign(&message);
-		assert!(public.verify(&signature, message));
+		assert!(public.verify(&signature, &message));
 	}
 
 	#[test]
@@ -933,7 +933,7 @@ mod tests {
 		// Signature is 64 bytes, so 128 chars + 2 quote chars
 		assert_eq!(serialized_signature.len(), 130);
 		let signature = serde_json::from_str(&serialized_signature).unwrap();
-		assert!(pair.public().verify(&signature, &message));
+		assert!(pair.public().verify(&signature, message));
 	}
 
 	#[test]

--- a/substrate/primitives/keyring/src/ed25519.rs
+++ b/substrate/primitives/keyring/src/ed25519.rs
@@ -19,6 +19,7 @@
 
 pub use sp_core::ed25519;
 use sp_core::{
+	crypto::UncheckedFrom,
 	ed25519::{Pair, Public, Signature},
 	hex2array, ByteArray, Pair as PairT, H256,
 };
@@ -53,19 +54,11 @@ impl Keyring {
 	}
 
 	pub fn from_raw_public(who: [u8; 32]) -> Option<Keyring> {
-		Self::from_public(&Public::from_raw(who))
+		Self::from_public(&Public::unchecked_from(who))
 	}
 
 	pub fn to_raw_public(self) -> [u8; 32] {
-		*Public::from(self).as_array_ref()
-	}
-
-	pub fn from_h256_public(who: H256) -> Option<Keyring> {
-		Self::from_public(&Public::from_raw(who.into()))
-	}
-
-	pub fn to_h256_public(self) -> H256 {
-		Public::from(self).as_array_ref().into()
+		Public::from(self).into()
 	}
 
 	pub fn to_raw_public_vec(self) -> Vec<u8> {
@@ -128,7 +121,7 @@ impl From<Keyring> for sp_runtime::MultiSigner {
 
 impl From<Keyring> for Public {
 	fn from(k: Keyring) -> Self {
-		Public::from_raw(k.into())
+		Public::unchecked_from(k.into())
 	}
 }
 

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -341,6 +341,7 @@ pub enum MultiSigner {
 
 impl FromEntropy for MultiSigner {
 	fn from_entropy(input: &mut impl codec::Input) -> Result<Self, codec::Error> {
+		// This buffer must be large enough to accomodate the larger seed of the supported crypto.
 		Ok(match input.read_byte()? % 3 {
 			0 => Self::Ed25519(FromEntropy::from_entropy(input)?),
 			1 => Self::Sr25519(FromEntropy::from_entropy(input)?),
@@ -353,7 +354,7 @@ impl FromEntropy for MultiSigner {
 /// we convert the hash into some AccountId, it's fine to use any scheme.
 impl<T: Into<H256>> crypto::UncheckedFrom<T> for MultiSigner {
 	fn unchecked_from(x: T) -> Self {
-		ed25519::Public::unchecked_from(x.into()).into()
+		ed25519::Public::unchecked_from(x.into().0).into()
 	}
 }
 
@@ -488,13 +489,13 @@ impl Verify for AnySignature {
 
 impl From<sr25519::Signature> for AnySignature {
 	fn from(s: sr25519::Signature) -> Self {
-		Self(s.into())
+		Self(H512::from(s.as_ref()))
 	}
 }
 
 impl From<ed25519::Signature> for AnySignature {
 	fn from(s: ed25519::Signature) -> Self {
-		Self(s.into())
+		Self(H512::from(s.as_ref()))
 	}
 }
 

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -341,7 +341,6 @@ pub enum MultiSigner {
 
 impl FromEntropy for MultiSigner {
 	fn from_entropy(input: &mut impl codec::Input) -> Result<Self, codec::Error> {
-		// This buffer must be large enough to accomodate the larger seed of the supported crypto.
 		Ok(match input.read_byte()? % 3 {
 			0 => Self::Ed25519(FromEntropy::from_entropy(input)?),
 			1 => Self::Sr25519(FromEntropy::from_entropy(input)?),

--- a/substrate/primitives/runtime/src/testing.rs
+++ b/substrate/primitives/runtime/src/testing.rs
@@ -86,6 +86,8 @@ impl UintAuthorityId {
 
 impl CryptoType for UintAuthorityId {
 	type Pair = Dummy;
+	type Public = Dummy;
+	type Signature = Dummy;
 }
 
 impl AsRef<[u8]> for UintAuthorityId {

--- a/substrate/primitives/runtime/src/traits.rs
+++ b/substrate/primitives/runtime/src/traits.rs
@@ -128,12 +128,13 @@ impl Verify for sp_core::sr25519::Signature {
 
 impl Verify for sp_core::ecdsa::Signature {
 	type Signer = sp_core::ecdsa::Public;
+
 	fn verify<L: Lazy<[u8]>>(&self, mut msg: L, signer: &sp_core::ecdsa::Public) -> bool {
 		match sp_io::crypto::secp256k1_ecdsa_recover_compressed(
 			self.as_ref(),
 			&sp_io::hashing::blake2_256(msg.get()),
 		) {
-			Ok(pubkey) => signer.as_ref() == &pubkey[..],
+			Ok(pubkey) => &signer[..] == &pubkey[..],
 			_ => false,
 		}
 	}


### PR DESCRIPTION
- Move the `Signature` and `Public` associated types to `CryptoType`
    - Inline with `AppCrypto` and `CryptoVrf` (which now have a similar design)
    - Properly constrain the associated types
- `Public` trait now exposes a `verify` method
- `Pair::verify` method has been deprecated in favor of `Public::verify`
    - Rationale: this is by far a lot more quite more popular interface for verifying signatures
- New `Signature` trait 
   - Provides a default implementation of `verify` which just calls into `Public::verify`
- Remove `Clone` implementation from secrets (`Pair`s and `AppPair`s).
- `impl_crypto_type` macro to implement `CryptoType` for the `(Secret, Public, Signature)` triple
- `impl_byte_array` macro to help implement common traits for byte array newtypes

---

Notes for follow up: 
- consider making a common `Seed` type of 32 bytes
- consider removing some "redundant" methods from the various `Public` and `Signature` types. Or at least make them consistent across the various wrappers (currently api methods are not very consistent) 